### PR TITLE
feat: add Student Entity and Implement JPA-Based Persistence

### DIFF
--- a/01-crud-demo-student/src/main/java/np/com/krishnabk/cruddemo/Application.java
+++ b/01-crud-demo-student/src/main/java/np/com/krishnabk/cruddemo/Application.java
@@ -1,5 +1,6 @@
 package np.com.krishnabk.cruddemo;
 
+import np.com.krishnabk.cruddemo.dao.StudentDAO;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -13,7 +14,7 @@ public class Application {
     }
 
     @Bean
-    public CommandLineRunner commandLineRunner(String[] args){
+    public CommandLineRunner commandLineRunner(StudentDAO studentDAO){
         return runner -> {
             System.out.println("Hello World");
         };

--- a/01-crud-demo-student/src/main/java/np/com/krishnabk/cruddemo/Application.java
+++ b/01-crud-demo-student/src/main/java/np/com/krishnabk/cruddemo/Application.java
@@ -1,6 +1,7 @@
 package np.com.krishnabk.cruddemo;
 
 import np.com.krishnabk.cruddemo.dao.StudentDAO;
+import np.com.krishnabk.cruddemo.entity.Student;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -16,7 +17,21 @@ public class Application {
     @Bean
     public CommandLineRunner commandLineRunner(StudentDAO studentDAO){
         return runner -> {
-            System.out.println("Hello World");
+            createStudent(studentDAO);
         };
+    }
+
+    private void createStudent(StudentDAO studentDAO) {
+
+        // create the student object
+        System.out.println("Creating new student object ...");
+        Student tempStudent = new Student("Jon", "Doe", "jon@gmail.com");
+
+        // save the student object
+        System.out.println("Saving the student object");
+        studentDAO.save(tempStudent);
+
+        // display the id of the saved student
+        System.out.println("Saved student. Generated ID: " + tempStudent.getId());
     }
 }

--- a/01-crud-demo-student/src/main/java/np/com/krishnabk/cruddemo/dao/StudentDAO.java
+++ b/01-crud-demo-student/src/main/java/np/com/krishnabk/cruddemo/dao/StudentDAO.java
@@ -1,0 +1,7 @@
+package np.com.krishnabk.cruddemo.dao;
+
+import np.com.krishnabk.cruddemo.entity.Student;
+
+public interface StudentDAO {
+    void save(Student theStudent);
+}

--- a/01-crud-demo-student/src/main/java/np/com/krishnabk/cruddemo/dao/StudentDAOImpl.java
+++ b/01-crud-demo-student/src/main/java/np/com/krishnabk/cruddemo/dao/StudentDAOImpl.java
@@ -1,0 +1,28 @@
+package np.com.krishnabk.cruddemo.dao;
+
+import jakarta.persistence.EntityManager;
+import np.com.krishnabk.cruddemo.entity.Student;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+public class StudentDAOImpl implements StudentDAO{
+
+    // define field for entity manager
+    private EntityManager entityManager;
+
+
+    // inject entity manager using constructor injection
+    @Autowired
+    public StudentDAOImpl(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    // implement save method
+    @Override
+    @Transactional
+    public void save(Student theStudent) {
+        entityManager.persist(theStudent);
+    }
+}

--- a/01-crud-demo-student/src/main/java/np/com/krishnabk/cruddemo/entity/Student.java
+++ b/01-crud-demo-student/src/main/java/np/com/krishnabk/cruddemo/entity/Student.java
@@ -1,0 +1,82 @@
+package np.com.krishnabk.cruddemo.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "student")
+public class Student {
+
+    // define fields
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private int id;
+
+    @Column(name = "first_name")
+    private String firstName;
+
+    @Column(name = "last_name")
+    private String lastName;
+
+    @Column(name = "email")
+    private String email;
+
+    // define constructors
+
+    public Student(){
+
+    }
+
+    public Student(String firstName, String lastName, String email) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.email = email;
+    }
+
+    // define getters/setters
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    // define toString() method
+
+    @Override
+    public String toString() {
+        return "Student{" +
+                "id=" + id +
+                ", firstName='" + firstName + '\'' +
+                ", lastName='" + lastName + '\'' +
+                ", email='" + email + '\'' +
+                '}';
+    }
+}


### PR DESCRIPTION
This PR introduces full JPA support for the Student domain model, enabling persistent storage via a data access layer. It includes:

- `Student` entity with proper JPA annotations.
- `StudentDAO` interface defining a save contract.
- `StudentDAOImpl` providing JPA-based implementation of the DAO.
- `Integration` of DAO into `CommandLineRunner`.
- Creation and saving of a sample student at application startup.

![image](https://github.com/user-attachments/assets/c618dfe9-5077-4dec-a55c-ec01c8b66832)
